### PR TITLE
Replace - with _ in callback generation

### DIFF
--- a/core-shared-lib.html
+++ b/core-shared-lib.html
@@ -68,7 +68,7 @@ Whenever possible, use **import** (`<link rel="import" href="...">`) instead.
   }
   
   function nameFromUrl(url) {
-    return url.replace(/[\:\/\%\?\&\.\=]/g, '_') + '_api';
+    return url.replace(/[\:\/\%\?\&\.\=\-]/g, '_') + '_api';
   }
 
   var Loader = function(name, url, callbackName) {


### PR DESCRIPTION
Having a "-" character in your URL causes a callback to be generated with an invalid function name.  Observed in PolymerLabs/google-apis@924dd1bb5d648a85f5684a74d683aa6d2610d0d1.
