### PR TITLE
Remove Immediately-invoked function expression pattern

### DIFF
--- a/core-shared-lib.html
+++ b/core-shared-lib.html
@@ -32,8 +32,7 @@ lib.html:
 -->
 <polymer-element name="core-shared-lib" attributes="url notifyEvent callbackName">
 <script>
-(function() {
-  
+
   Polymer({
     
     notifyEvent: 'core-shared-lib-load',
@@ -146,6 +145,5 @@ lib.html:
     
   };
   
-})();
 </script>
 </polymer-element>


### PR DESCRIPTION
This pattern causes errors with vulcanize. Moreover, it is the only polymer package that uses it.
