### PR TITLE
Add package name to Polymer registration process

### DIFF
--- a/core-shared-lib.html
+++ b/core-shared-lib.html
@@ -34,7 +34,7 @@ lib.html:
 <script>
 (function() {
   
-  Polymer({
+  Polymer('core-shared-lib', {
     
     notifyEvent: 'core-shared-lib-load',
     


### PR DESCRIPTION
The lack of name triggers errors when using vulcanize
