### PR TITLE
Loader shouldn't expect script tag

### DIFF
--- a/components/core-shared-lib/core-shared-lib.html
+++ b/components/core-shared-lib/core-shared-lib.html
@@ -105,7 +105,13 @@ lib.html:
       script.src = src;
       script.onerror = this.error.bind(this);
       var s = document.querySelector('script');
-      s.parentNode.insertBefore(script, s);
+      if (s) {
+        s.parentNode.insertBefore(script, s);
+      } else {
+        s = docoment.querySelector('head');
+        script.async = true;
+        s.appendChild(script);
+      }
       this.script = script;
     },
     

--- a/components/core-shared-lib/core-shared-lib.html
+++ b/components/core-shared-lib/core-shared-lib.html
@@ -108,7 +108,7 @@ lib.html:
       if (s) {
         s.parentNode.insertBefore(script, s);
       } else {
-        s = docoment.querySelector('head');
+        s = document.querySelector('head');
         script.async = true;
         s.appendChild(script);
       }


### PR DESCRIPTION
Using Web Components / Polymer, we shouldn't expect page to contain a script tag to begin with.